### PR TITLE
Compile templates with Tera through files TLA

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
 - compile KCPs from `.tgz` archives with files at root
 - `package` command to create `.tgz` archives for valid KCPs
+- inject TLA function for compiling files with Jinja like engine
 
 ## [0.1.0] - 2020-09-29
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -73,6 +73,42 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf1de2fe8c75bc145a2f577add951f8134889b4795d47466a54a5c846d691693"
 
 [[package]]
+name = "block-buffer"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0940dc441f31689269e10ac70eb1002a3a1d3ad1390e030043662eb7fe4688b"
+dependencies = [
+ "block-padding",
+ "byte-tools",
+ "byteorder",
+ "generic-array",
+]
+
+[[package]]
+name = "block-padding"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa79dedbb091f449f1f39e53edf88d5dbe95f895dae6135a8d7b881fb5af73f5"
+dependencies = [
+ "byte-tools",
+]
+
+[[package]]
+name = "bstr"
+version = "0.2.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "31accafdb70df7871592c058eca3985b71104e15ac32f64706022c58867da931"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "byte-tools"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3b5ca7a04898ad4bcd41c90c5285445ff5b791899bb1b0abdd2a2aa791211d7"
+
+[[package]]
 name = "byteorder"
 version = "1.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -93,6 +129,16 @@ dependencies = [
  "num-integer",
  "num-traits",
  "time",
+]
+
+[[package]]
+name = "chrono-tz"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2554a3155fec064362507487171dcc4edc3df60cb10f3a1fb10ed8094822b120"
+dependencies = [
+ "chrono",
+ "parse-zoneinfo",
 ]
 
 [[package]]
@@ -126,6 +172,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossbeam-utils"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3c7c73a2d1e9fc0886a08b93e98eb643461230d5f1925e4036204d5f2e261a8"
+dependencies = [
+ "autocfg",
+ "cfg-if",
+ "lazy_static",
+]
+
+[[package]]
+name = "deunicode"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "850878694b7933ca4c9569d30a34b55031b9b139ee1fc7b94a527c4ef960d690"
+
+[[package]]
+name = "digest"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3d0c8c8752312f9713efd397ff63acb9f85585afbf179282e720e7704954dd5"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
 name = "error-chain"
 version = "0.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -133,6 +205,12 @@ checksum = "2d2f06b9cac1506ece98fe3231e3cc9c4410ec3d5b1f24ae1c8946f0742cdefc"
 dependencies = [
  "version_check",
 ]
+
+[[package]]
+name = "fake-simd"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e88a8acf291dafb59c2d96e8f59828f3838bb1a70398823ade51a84de6a6deed"
 
 [[package]]
 name = "filetime"
@@ -159,6 +237,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "fnv"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
+name = "generic-array"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c68f0274ae0e023facc3c97b2e00f076be70e254bc851d972503b328db79b2ec"
+dependencies = [
+ "typenum",
+]
+
+[[package]]
 name = "getrandom"
 version = "0.1.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -167,6 +260,30 @@ dependencies = [
  "cfg-if",
  "libc",
  "wasi 0.9.0+wasi-snapshot-preview1",
+]
+
+[[package]]
+name = "globset"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ad1da430bd7281dde2576f44c84cc3f0f7b475e7202cd503042dff01a8c8120"
+dependencies = [
+ "aho-corasick",
+ "bstr",
+ "fnv",
+ "log",
+ "regex",
+]
+
+[[package]]
+name = "globwalk"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "178270263374052c40502e9f607134947de75302c1348d1a0e31db67c1691446"
+dependencies = [
+ "bitflags",
+ "ignore",
+ "walkdir",
 ]
 
 [[package]]
@@ -189,6 +306,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "humansize"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6cab2627acfc432780848602f3f558f7e9dd427352224b0d9324025796d2a5e"
+
+[[package]]
 name = "idna"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -197,6 +320,24 @@ dependencies = [
  "matches",
  "unicode-bidi",
  "unicode-normalization",
+]
+
+[[package]]
+name = "ignore"
+version = "0.4.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22dcbf2a4a289528dbef21686354904e1c694ac642610a9bff9e7df730d9ec72"
+dependencies = [
+ "crossbeam-utils",
+ "globset",
+ "lazy_static",
+ "log",
+ "memchr",
+ "regex",
+ "same-file",
+ "thread_local",
+ "walkdir",
+ "winapi-util",
 ]
 
 [[package]]
@@ -302,6 +443,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2f96b10ec2560088a8e76961b00d47107b3a625fecb76dedb29ee7ccbf98235"
 
 [[package]]
+name = "log"
+version = "0.4.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fabed175da42fed1fa0746b0ea71f412aa9d35e76e95e59b192c64b9dc2bf8b"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
+name = "maplit"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e2e65a1a2e43cfcb47a895c4c8b10d1f4a61097f9f254f183aee60cad9c651d"
+
+[[package]]
 name = "matches"
 version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -349,18 +505,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "opaque-debug"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2839e79665f131bdb5782e51f2c6c9599c133c6098982a54c794358bf432529c"
+
+[[package]]
 name = "package"
 version = "0.1.0"
 dependencies = [
  "flate2",
+ "globwalk",
  "helper",
  "jrsonnet-evaluator",
+ "jrsonnet-parser",
  "serde",
  "serde_json",
  "tar",
  "tempfile",
+ "tera",
  "url",
  "valico",
+]
+
+[[package]]
+name = "parse-zoneinfo"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c705f256449c60da65e11ff6626e0c16a0a0b96aaa348de61376b249bc340f41"
+dependencies = [
+ "regex",
 ]
 
 [[package]]
@@ -401,6 +575,49 @@ name = "percent-encoding"
 version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4fd5641d01c8f18a23da7b6fe29298ff4b55afcccdf78973b24cf3175fee32e"
+
+[[package]]
+name = "pest"
+version = "2.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10f4872ae94d7b90ae48754df22fd42ad52ce740b8f370b03da4835417403e53"
+dependencies = [
+ "ucd-trie",
+]
+
+[[package]]
+name = "pest_derive"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "833d1ae558dc601e9a60366421196a8d94bc0ac980476d0b67e1d0988d72b2d0"
+dependencies = [
+ "pest",
+ "pest_generator",
+]
+
+[[package]]
+name = "pest_generator"
+version = "2.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "99b8db626e31e5b81787b9783425769681b347011cc59471e33ea46d2ea0cf55"
+dependencies = [
+ "pest",
+ "pest_meta",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "pest_meta"
+version = "2.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "54be6e404f5317079812fc8f9f5279de376d8856929e21c184ecf6bbd692a11d"
+dependencies = [
+ "maplit",
+ "pest",
+ "sha-1",
+]
 
 [[package]]
 name = "phf"
@@ -574,6 +791,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "71d301d4193d031abdd79ff7e3dd721168a9572ef3fe51a1517aba235bd8f86e"
 
 [[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
+]
+
+[[package]]
 name = "serde"
 version = "1.0.116"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -605,10 +831,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha-1"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7d94d0bede923b3cea61f3f1ff57ff8cdfd77b400fb8f9998949e0cf04163df"
+dependencies = [
+ "block-buffer",
+ "digest",
+ "fake-simd",
+ "opaque-debug",
+]
+
+[[package]]
 name = "siphasher"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fa8f3741c7372e75519bd9346068370c9cdaabcc1f9599cbcf2a2719352286b7"
+
+[[package]]
+name = "slug"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b3bc762e6a4b6c6fcaade73e77f9ebc6991b676f88bb2358bddb56560f073373"
+dependencies = [
+ "deunicode",
+]
 
 [[package]]
 name = "strsim"
@@ -671,6 +918,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "tera"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1381c83828bedd5ce4e59473110afa5381ffe523406d9ade4b77c9f7be70ff9a"
+dependencies = [
+ "chrono",
+ "chrono-tz",
+ "globwalk",
+ "humansize",
+ "lazy_static",
+ "percent-encoding",
+ "pest",
+ "pest_derive",
+ "rand",
+ "regex",
+ "serde",
+ "serde_json",
+ "slug",
+ "unic-segment",
+]
+
+[[package]]
 name = "textwrap"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -726,10 +995,72 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "238ce071d267c5710f9d31451efec16c5ee22de34df17cc05e56cbc92e967117"
 
 [[package]]
+name = "typenum"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "373c8a200f9e67a0c95e62a4f52fbf80c23b4381c05a17845531982fa99e6b33"
+
+[[package]]
+name = "ucd-trie"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56dee185309b50d1f11bfedef0fe6d036842e3fb77413abef29f8f8d1c5d4c1c"
+
+[[package]]
 name = "unescape"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccb97dac3243214f8d8507998906ca3e2e0b900bf9bf4870477f125b82e68f6e"
+
+[[package]]
+name = "unic-char-property"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8c57a407d9b6fa02b4795eb81c5b6652060a15a7903ea981f3d723e6c0be221"
+dependencies = [
+ "unic-char-range",
+]
+
+[[package]]
+name = "unic-char-range"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0398022d5f700414f6b899e10b8348231abf9173fa93144cbc1a43b9793c1fbc"
+
+[[package]]
+name = "unic-common"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "80d7ff825a6a654ee85a63e80f92f054f904f21e7d12da4e22f9834a4aaa35bc"
+
+[[package]]
+name = "unic-segment"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e4ed5d26be57f84f176157270c112ef57b86debac9cd21daaabbe56db0f88f23"
+dependencies = [
+ "unic-ucd-segment",
+]
+
+[[package]]
+name = "unic-ucd-segment"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2079c122a62205b421f499da10f3ee0f7697f012f55b675e002483c73ea34700"
+dependencies = [
+ "unic-char-property",
+ "unic-char-range",
+ "unic-ucd-version",
+]
+
+[[package]]
+name = "unic-ucd-version"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96bd2f2237fe450fcd0a1d2f5f4e91711124f7857ba2e964247776ebeeb7b0c4"
+dependencies = [
+ "unic-common",
+]
 
 [[package]]
 name = "unicode-bidi"
@@ -813,6 +1144,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5a972e5669d67ba988ce3dc826706fb0a8b01471c088cb0b6110b805cc36aed"
 
 [[package]]
+name = "walkdir"
+version = "2.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "777182bc735b6424e1a57516d35ed72cb8019d85c8c9bf536dccb3445c1a2f7d"
+dependencies = [
+ "same-file",
+ "winapi",
+ "winapi-util",
+]
+
+[[package]]
 name = "wasi"
 version = "0.9.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -839,6 +1181,15 @@ name = "winapi-i686-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-util"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70ec6ce85bb158151cae5e5c87f95a8e97d2c0c4b001223f33a334e3ce5de178"
+dependencies = [
+ "winapi",
+]
 
 [[package]]
 name = "winapi-x86_64-pc-windows-gnu"

--- a/package/Cargo.toml
+++ b/package/Cargo.toml
@@ -6,11 +6,14 @@ edition = "2018"
 
 [dependencies]
 flate2 = "1.0.17"
+globwalk = "0.8.0"
 helper = { path = "../helper" }
 jrsonnet-evaluator = "0.3.1"
+jrsonnet-parser = "0.3.1"
 serde = "1.0.115"
 serde_json = "1.0"
 tar = "0.4.30"
 tempfile = "3.1.0"
+tera = "1"
 url = "2.1.1"
 valico = "3.4.0"

--- a/package/src/compile.rs
+++ b/package/src/compile.rs
@@ -1,26 +1,37 @@
 use crate::error::{Error, Result};
 use crate::Package;
+use globwalk::{DirEntry, GlobWalkerBuilder};
 use jrsonnet_evaluator::{
+	error::Error as JrError,
 	error::LocError,
+	native::NativeCallback,
 	trace::{ExplainingFormat, PathResolver},
-	EvaluationState, FileImportResolver, Val,
+	EvaluationState, FileImportResolver, FuncVal, Val,
 };
-use serde_json::Value;
+use jrsonnet_parser::{Param, ParamsDesc};
+use serde_json::{Map, Value};
+use std::fs;
+use std::path::PathBuf;
+use std::rc::Rc;
+use tera::{Context, Tera};
 
 const VALUES_PARAM: &str = "values";
+const FILES_PARAM: &str = "files";
+const TEMPLATES_FOLDER: &str = "files";
 
-pub fn compile(pkg: Package, values: Option<Value>) -> Result<Value> {
-	let values = validate_values(&pkg, values)?;
+pub fn compile(pkg: Package, values: Value) -> Result<Value> {
 	let state = create_state(&pkg);
 
 	let render_issue = |err: LocError| Error::RenderIssue(format!("{}", err.error()));
+
+	state.add_tla(FILES_PARAM.into(), create_files_func(&pkg, &values));
 
 	state
 		.add_tla_code(VALUES_PARAM.into(), values.to_string().into())
 		.map_err(render_issue)?;
 
 	let parsed = state
-		.evaluate_file_raw_nocwd(&pkg.spec.main)
+		.evaluate_file_raw(&pkg.spec.main)
 		.map_err(render_issue)?;
 
 	let parsed = match parsed {
@@ -51,17 +62,85 @@ fn create_state(pkg: &Package) -> EvaluationState {
 	state
 }
 
-fn validate_values(pkg: &Package, values: Option<Value>) -> Result<Value> {
-	let (schema, values) = match (&pkg.schema, values) {
-		(None, None) => return Ok(Value::Null),
-		(None, Some(_)) => return Err(Error::NoSchema),
-		(Some(_), None) => return Err(Error::NoValues),
-		(Some(schema), Some(value)) => (schema, value),
+fn create_files_func(pkg: &Package, values: &Value) -> Val {
+	let params = ParamsDesc(Rc::new(vec![Param("name".into(), None)]));
+
+	let root = pkg.root.clone();
+	let values = values.clone();
+	let render = move |params: &[Val]| -> std::result::Result<Val, LocError> {
+		let name = params.get(0).unwrap();
+		let file = match name {
+			Val::Str(name) => name,
+			_ => {
+				return Err(LocError::new(JrError::AssertionFailed(
+					"name should be a string".into(),
+				)))
+			}
+		};
+
+		let compiled = compile_template(&root, file, &values)
+			.map_err(|err| LocError::new(JrError::RuntimeError(err.into())))?;
+
+		if compiled.is_empty() {
+			Err(LocError::new(JrError::RuntimeError(
+				format!("No template found for glob {}", file).into(),
+			)))
+		} else if compiled.len() == 1 {
+			Ok(Val::Str(compiled.into_iter().next().unwrap().into()))
+		} else {
+			Ok(Val::Arr(
+				compiled
+					.into_iter()
+					.map(|comp| Val::Str(comp.into()))
+					.collect::<Vec<Val>>()
+					.into(),
+			))
+		}
 	};
 
-	if schema.validate(&values) {
-		Ok(values)
-	} else {
-		Err(Error::InvalidValues)
+	let func = NativeCallback::new(params, render);
+	let ext: Rc<FuncVal> = FuncVal::NativeExt("files".into(), func.into()).into();
+
+	Val::Func(ext)
+}
+
+fn compile_template(
+	root: &PathBuf,
+	glob: &str,
+	values: &Value,
+) -> std::result::Result<Vec<String>, String> {
+	let mut templates_dir = root.clone();
+	templates_dir.push(TEMPLATES_FOLDER);
+
+	if !templates_dir.exists() {
+		return Err(String::from("No files folder to search for templates"));
 	}
+
+	let globwalker = GlobWalkerBuilder::new(templates_dir, glob)
+		.build()
+		.map_err(|err| format!("Invalid glob provided ({}): {}", glob, err))?;
+
+	let dirs: Vec<DirEntry> = globwalker
+		.collect::<std::result::Result<_, _>>()
+		.map_err(|err| format!("Unable to resolve globs: {}", err))?;
+
+	let contents: Vec<String> = dirs
+		.into_iter()
+		.map(DirEntry::into_path)
+		.map(fs::read_to_string)
+		.collect::<std::result::Result<_, _>>()
+		.map_err(|err| format!("Unable to read templates: {}", err))?;
+
+	let context = match values {
+		Value::Null => Context::from_serialize(Value::Object(Map::new())).unwrap(),
+		_ => Context::from_serialize(values).unwrap(),
+	};
+
+	let compiled: Vec<String> = contents
+		.into_iter()
+		.map(|content| Tera::one_off(&content, &context, true))
+		.collect::<std::result::Result<_, _>>()
+		.map_err(|err| format!("Unable to compile templates: {}", err))?;
+
+	Ok(compiled)
 }

--- a/package/src/lib.rs
+++ b/package/src/lib.rs
@@ -69,6 +69,23 @@ impl Package {
 	}
 
 	pub fn compile(self, values: Option<Value>) -> Result<Value> {
+		let values = validate_values(&self, values)?;
+
 		compile::compile(self, values)
+	}
+}
+
+fn validate_values(pkg: &Package, values: Option<Value>) -> Result<Value> {
+	let (schema, values) = match (&pkg.schema, values) {
+		(None, None) => return Ok(Value::Null),
+		(None, Some(_)) => return Err(Error::NoSchema),
+		(Some(_), None) => return Err(Error::NoValues),
+		(Some(schema), Some(value)) => (schema, value),
+	};
+
+	if schema.validate(&values) {
+		Ok(values)
+	} else {
+		Err(Error::InvalidValues)
 	}
 }

--- a/package/tests/fixtures/files/database.toml
+++ b/package/tests/fixtures/files/database.toml
@@ -1,0 +1,2 @@
+[settings]
+secret = {{ secret }}

--- a/package/tests/fixtures/files/events/settings.toml
+++ b/package/tests/fixtures/files/events/settings.toml
@@ -1,0 +1,2 @@
+[setup]
+secret = {{ secret }}

--- a/package/tests/fixtures/files/invalid.ini
+++ b/package/tests/fixtures/files/invalid.ini
@@ -1,0 +1,1 @@
+setup = {{ secret

--- a/package/tests/fixtures/files/no-params.txt
+++ b/package/tests/fixtures/files/no-params.txt
@@ -1,0 +1,1 @@
+I'm pure secret

--- a/package/tests/fixtures/import.jsonnet
+++ b/package/tests/fixtures/import.jsonnet
@@ -1,5 +1,5 @@
 local valid = import 'valid.jsonnet';
 
-function(values) {
+function(values, files) {
 	imported: valid(values),
 }

--- a/package/tests/fixtures/mod.rs
+++ b/package/tests/fixtures/mod.rs
@@ -4,10 +4,19 @@ use std::env;
 use std::fs;
 use std::path::PathBuf;
 use tempfile::TempDir;
+use tera::{Context, Tera};
 
 pub struct Fixture {}
 
 impl Fixture {
+	fn root() -> PathBuf {
+		let root_dir = &env::var("CARGO_MANIFEST_DIR").expect("$CARGO_MANIFEST_DIR");
+
+		let mut source = PathBuf::from(root_dir);
+		source.push("tests/fixtures");
+		source
+	}
+
 	pub fn dir(with: &[&str]) -> TempDir {
 		let sources = with.iter().map(|name| Self::path(name));
 
@@ -19,6 +28,11 @@ impl Fixture {
 			target
 		});
 
+		make_dirs(
+			&PathBuf::from(tempdir.path()),
+			&with.iter().map(PathBuf::from).collect::<Vec<PathBuf>>(),
+		);
+
 		for (source, target) in sources.zip(targets) {
 			fs::copy(source, target).unwrap();
 		}
@@ -27,10 +41,7 @@ impl Fixture {
 	}
 
 	pub fn path(name: &str) -> PathBuf {
-		let root_dir = &env::var("CARGO_MANIFEST_DIR").expect("$CARGO_MANIFEST_DIR");
-
-		let mut source = PathBuf::from(root_dir);
-		source.push("tests/fixtures");
+		let mut source = Self::root();
 		source.push(name);
 
 		source
@@ -71,5 +82,27 @@ impl Fixture {
 			.map(|contents| serde_json::from_str(&contents))
 			.map(Result::unwrap)
 			.unwrap()
+	}
+
+	pub fn template(name: &str, values: Value) -> String {
+		let mut template = Self::root();
+		template.push("files");
+		template.push(name);
+
+		let contents = fs::read_to_string(template).unwrap();
+		let context = Context::from_serialize(values).unwrap();
+
+		Tera::one_off(&contents, &context, true).unwrap()
+	}
+}
+
+fn make_dirs(at: &PathBuf, paths: &[PathBuf]) {
+	for path in paths {
+		let mut target = at.clone();
+		let mut dir = path.clone();
+		dir.pop();
+
+		target.push(dir);
+		fs::create_dir_all(target).unwrap()
 	}
 }

--- a/package/tests/fixtures/plain-template.jsonnet
+++ b/package/tests/fixtures/plain-template.jsonnet
@@ -1,0 +1,3 @@
+function(values, files) {
+	settings: files("no-params.txt"),
+}

--- a/package/tests/fixtures/valid.jsonnet
+++ b/package/tests/fixtures/valid.jsonnet
@@ -1,3 +1,3 @@
-function(values = null) {
+function(values = null, files = null) {
 	values: values,
 }

--- a/package/tests/fixtures/with-invalid-template.jsonnet
+++ b/package/tests/fixtures/with-invalid-template.jsonnet
@@ -1,0 +1,4 @@
+function(values, files) {
+	values: values,
+	settings: files("invalid.ini"),
+}

--- a/package/tests/fixtures/with-multiple-templates.jsonnet
+++ b/package/tests/fixtures/with-multiple-templates.jsonnet
@@ -1,0 +1,4 @@
+function(values, files) {
+	values: values,
+	settings: files("**/*.toml"),
+}

--- a/package/tests/fixtures/with-template.jsonnet
+++ b/package/tests/fixtures/with-template.jsonnet
@@ -1,0 +1,4 @@
+function(values, files) {
+	values: values,
+	settings: files("database.toml"),
+}


### PR DESCRIPTION
To enable applications that need configuration through files, without
embedding those within the Jsonnet templates with string, I've added a
new TLA named files, a function capable of compiling any file within
`files` KCP using Tera, a Jinja like template engine.

The `files` function can compile single templates if you provide a glob
that resolves to a single file, which results in the string of the
compiled template. But, it's also capable of compiling multiple
templates matching a glob, which results in an array of strings without
any guarantees on ordering.

Close: #6