### PR TITLE
Add parameters to filter output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - compile KCPs from `.tgz` archives with files at root
 - `package` command to create `.tgz` archives for valid KCPs
-- add `files` function to the global for compiling files with Jinja like engine
+- `files` function to the global for compiling files with Jinja like engine
+- `--only` and `--except` parameters on `compile` to control which objects should be yielded
 
 ### Changed
 

--- a/kube/tests/find.rs
+++ b/kube/tests/find.rs
@@ -1,6 +1,7 @@
-use kube::{Error, Result};
+use kube::{Error, Filter, Result};
 use serde_json::Value;
 use std::iter;
+use std::path::PathBuf;
 
 const MINIMAL_OBJECT: &str = r#"{
 	"kind": "Deployment",
@@ -11,7 +12,7 @@ type Return = Result<Vec<Value>>;
 
 fn find_from(text: &str) -> Return {
 	let val: Value = serde_json::from_str(text).unwrap();
-	kube::find(&val)
+	kube::find(&val, &Filter::default())
 }
 
 fn assert_invalid(err: Return) {
@@ -77,5 +78,130 @@ fn disallow_primitives() {
 	for &json in values.iter() {
 		let found = find_from(&json);
 		assert_invalid(found);
+	}
+}
+
+mod filter {
+	use super::*;
+
+	fn find_within_minimal(filter: &Filter) -> Return {
+		let val = serde_json::from_str(MINIMAL_OBJECT).unwrap();
+		kube::find(&val, &filter)
+	}
+
+	fn find_within_complex(filter: &Filter) -> Return {
+		let complex: Value = serde_json::from_str(&format!(
+			r#"{{ "a": {{ "b": {0}, "c": {{ "d": {0}, "e": {0} }}, "f": {0} }}, "g": {0} }}"#,
+			MINIMAL_OBJECT
+		))
+		.unwrap();
+
+		kube::find(&complex, filter)
+	}
+
+	#[test]
+	fn keeps_only_paths() {
+		let cases = vec![
+			(vec!["/"], 5),
+			(vec!["/a/b"], 1),
+			(vec!["/a/c"], 2),
+			(vec!["/a/b/c"], 0),
+			(vec!["/a/c/d", "/a/c"], 2),
+			(vec!["/a/c/d", "/a/c/e", "/a/f"], 3),
+			(vec!["/a/f", "/g"], 2),
+			(vec!["/g", "/a/c"], 3),
+		]
+		.into_iter()
+		.map(|(vec, n)| (vec.iter().map(PathBuf::from).collect(), n));
+
+		for (only, amount) in cases {
+			let filter = Filter {
+				only,
+				except: vec![],
+			};
+
+			let found = find_within_complex(&filter);
+			assert_valid(found, amount);
+		}
+
+		let found = find_within_minimal(&Filter {
+			except: vec![],
+			only: vec![PathBuf::from("/")],
+		});
+
+		assert_valid(found, 1);
+	}
+
+	#[test]
+	fn discards_disallowed_paths() {
+		let cases = vec![
+			(vec!["/"], 0),
+			(vec!["/a/b"], 4),
+			(vec!["/a/c"], 3),
+			(vec!["/a/b/c"], 5),
+			(vec!["/a/c/d", "/a/c"], 3),
+			(vec!["/a/c/d", "/a/c/e", "/a/f"], 2),
+			(vec!["/a/f", "/g"], 3),
+			(vec!["/g", "/a/c"], 2),
+		]
+		.into_iter()
+		.map(|(vec, n)| (vec.iter().map(PathBuf::from).collect(), n));
+
+		for (except, amount) in cases {
+			let filter = Filter {
+				except,
+				only: vec![],
+			};
+
+			let found = find_within_complex(&filter);
+			assert_valid(found, amount);
+		}
+
+		let found = find_within_minimal(&Filter {
+			except: vec![PathBuf::from("/")],
+			only: vec![],
+		});
+
+		assert_valid(found, 0);
+	}
+
+	#[test]
+	fn combines_permissions() {
+		let cases = vec![
+			(vec!["/"], vec!["/"], 0),
+			(vec!["/"], vec!["/a/b"], 4),
+			(vec!["/a/b", "/a/f"], vec!["/a/c"], 2),
+			(vec!["/a/c", "/a/b", "/a/f"], vec!["/a/c/d", "/a/b"], 2),
+			(vec!["/a/c/d", "/g"], vec!["/a/c"], 1),
+			(
+				vec!["/a/c/d", "/a/c/e", "/a/f", "/g"],
+				vec!["/a/f", "/a/c/e"],
+				2,
+			),
+			(vec!["/a"], vec!["/g", "/a/b/c"], 4),
+			(vec!["/a/b/c", "/a/c"], vec!["/a/c/e"], 1),
+		]
+		.into_iter()
+		.map(|(only, except, n)| {
+			(
+				only.iter().map(PathBuf::from).collect(),
+				except.iter().map(PathBuf::from).collect(),
+				n,
+			)
+		});
+
+		for (only, except, amount) in cases {
+			let filter = Filter { only, except };
+
+			let found = find_within_complex(&filter);
+			assert_valid(found, amount);
+		}
+
+		let found = find_within_minimal(&Filter {
+			except: vec![PathBuf::from("/")],
+			only: vec![PathBuf::from("/")],
+		});
+
+		assert_valid(found, 0);
 	}
 }


### PR DESCRIPTION
To give users more granular control over what's compiled so they can
deploy only fragments of their packages, I've added two new parameters
called `--only` and `--except` which will act as filters on the output
based on template structure/paths once compiled.

Close: #5